### PR TITLE
Use same background and color0

### DIFF
--- a/Xresources
+++ b/Xresources
@@ -1,7 +1,7 @@
 ! Dracula Xresources palette
 *.foreground: #F8F8F2
 *.background: #282A36
-*.color0:     #000000
+*.color0:     #282A36
 *.color8:     #4D4D4D
 *.color1:     #FF5555
 *.color9:     #FF6E67


### PR DESCRIPTION
This is the same way the gnome-terminal theme is.

Cannot take screenshots at the moment but I'll update this when I get the chance. This changes color0 to the default Dracula background color instead of the darkest black (#000000). This improves programs that specifically set color0 instead of using the default background, like mutt and MOC.